### PR TITLE
Old annotation support

### DIFF
--- a/src/java/edu/slu/tpen/entity/image/Canvas.java
+++ b/src/java/edu/slu/tpen/entity/image/Canvas.java
@@ -185,12 +185,12 @@ public class Canvas {
         reader.close();
         connection.disconnect();
         JSONArray theLists = JSONArray.fromObject(sb.toString());
-        System.out.println("Found "+theLists.size()+" lists matching those params.");
+        //System.out.println("Found "+theLists.size()+" lists matching those params.");
         String[] annotationLists = new String[theLists.size()];
         for(int i=0; i<theLists.size(); i++){
             JSONObject currentList = theLists.getJSONObject(i);
             String id = currentList.getString("@id");
-            System.out.println("List ID: "+id);
+            //System.out.println("List ID: "+id);
             annotationLists[i] = id;
         }
         return annotationLists;

--- a/src/java/edu/slu/tpen/entity/image/Canvas.java
+++ b/src/java/edu/slu/tpen/entity/image/Canvas.java
@@ -156,12 +156,12 @@ public class Canvas {
      * @return : The annotation list.
      */
     public static String[] getAnnotationListsForProject(Integer projectID, String canvasID, Integer UID) throws MalformedURLException, IOException {
-         URL postUrl = new URL(Constant.ANNOTATION_SERVER_ADDR + "/anno/getAnnotationByProperties.action");
-         JSONObject parameter = new JSONObject();
-         parameter.element("@type", "sc:AnnotationList");
-         parameter.element("proj", projectID);
-         parameter.element("on", canvasID);
-         System.out.println("Get anno list for proj "+projectID+" on canvas "+canvasID);
+        URL postUrl = new URL(Constant.ANNOTATION_SERVER_ADDR + "/anno/getAnnotationByProperties.action");
+        JSONObject parameter = new JSONObject();
+        parameter.element("@type", "sc:AnnotationList");
+        parameter.element("proj", projectID);
+        parameter.element("on", canvasID);
+        //System.out.println("Get anno list for proj "+projectID+" on canvas "+canvasID);
         HttpURLConnection connection = (HttpURLConnection) postUrl.openConnection();
         connection.setDoOutput(true);
         connection.setDoInput(true);

--- a/src/java/edu/slu/tpen/entity/image/Canvas.java
+++ b/src/java/edu/slu/tpen/entity/image/Canvas.java
@@ -17,6 +17,7 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.util.List;
 import net.sf.json.JSONArray;
+import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
 
 /**
@@ -194,4 +195,55 @@ public class Canvas {
         }
         return annotationLists;
     }
+    
+    /* 
+    @param resources: A JSON array of annotations that are all new (insert can be used).  
+    @return A JSONArray of annotations with their @id included.
+
+    The resources need to be saved and a JSON array of the objects with their @ids in them needs
+    to be returneds.
+    */
+    public static JSONArray bulkSaveAnnotations(JSONArray resources) throws MalformedURLException, IOException{
+        JSONArray new_resources = new JSONArray();
+        URL postUrlCopyAnno = new URL(Constant.ANNOTATION_SERVER_ADDR + "/anno/batchSaveFromCopy.action");
+        HttpURLConnection ucCopyAnno = (HttpURLConnection) postUrlCopyAnno.openConnection();
+        ucCopyAnno.setDoInput(true);
+        ucCopyAnno.setDoOutput(true);
+        ucCopyAnno.setRequestMethod("POST");
+        ucCopyAnno.setUseCaches(false);
+        ucCopyAnno.setInstanceFollowRedirects(true);
+        ucCopyAnno.addRequestProperty("content-type", "application/x-www-form-urlencoded");
+        ucCopyAnno.connect();
+        DataOutputStream dataOutCopyAnno = new DataOutputStream(ucCopyAnno.getOutputStream());
+        String str_resources = "";
+        if(resources.size() > 0){
+            str_resources = resources.toString();
+        }
+        else{
+            str_resources = "[]";
+        }
+        dataOutCopyAnno.writeBytes("content=" + URLEncoder.encode(str_resources, "utf-8"));
+        dataOutCopyAnno.flush();
+        dataOutCopyAnno.close();
+        BufferedReader returnedAnnoList = new BufferedReader(new InputStreamReader(ucCopyAnno.getInputStream(),"utf-8"));
+        String lines = "";
+        StringBuilder sbAnnoLines = new StringBuilder();
+        while ((lines = returnedAnnoList.readLine()) != null){
+//                                    System.out.println(lineAnnoLs);
+            sbAnnoLines.append(lines);
+        }
+        returnedAnnoList.close();
+        String parseThis = sbAnnoLines.toString();
+        JSONObject batchSaveResponse = JSONObject.fromObject(parseThis);
+        try{
+            new_resources = (JSONArray) batchSaveResponse.get("new_resources");
+        }
+        catch(JSONException e){
+           // System.out.println("Batch save response does not contain JSONARRAY in new_resouces.");
+        }
+        
+        return new_resources;
+    }
 }
+
+

--- a/src/java/edu/slu/tpen/servlet/util/CreateAnnoListUtil.java
+++ b/src/java/edu/slu/tpen/servlet/util/CreateAnnoListUtil.java
@@ -26,7 +26,7 @@ public class CreateAnnoListUtil {
         canvasList.element("forkFromID", "");
         canvasList.element("resources", resource);
         canvasList.element("proj", projectID);
-        //canvasList.element("testing", "msid_creation"); 
+        canvasList.element("testing", "msid_creation"); 
         return canvasList;
     }
 }

--- a/src/java/edu/slu/tpen/servlet/util/CreateAnnoListUtil.java
+++ b/src/java/edu/slu/tpen/servlet/util/CreateAnnoListUtil.java
@@ -26,7 +26,7 @@ public class CreateAnnoListUtil {
         canvasList.element("forkFromID", "");
         canvasList.element("resources", resource);
         canvasList.element("proj", projectID);
-        canvasList.element("testing", "msid_creation"); //TODO: remove when done testing.
+        //canvasList.element("testing", "msid_creation"); 
         return canvasList;
     }
 }

--- a/src/java/edu/slu/tpen/transfer/JsonLDExporter.java
+++ b/src/java/edu/slu/tpen/transfer/JsonLDExporter.java
@@ -115,7 +115,7 @@ public class JsonLDExporter {
       annotationList.element("@context", "http://iiif.io/api/presentation/2/context.json");
       //annotationList.element("testing", "msid_creation");
       //String canvasID = projName + "/canvas/" + URLEncoder.encode(f.getPageName(), "UTF-8");
-      Dimension pageDim = f.getImageDimension();
+      Dimension pageDim = ImageCache.getImageDimension(f.getFolioNumber());
       String[] otherContent;
       if (pageDim == null) {
          //LOG.log(Level.INFO, "Image for {0} not found in cache, loading image...", f.getFolioNumber());

--- a/src/java/edu/slu/tpen/transfer/JsonLDExporter.java
+++ b/src/java/edu/slu/tpen/transfer/JsonLDExporter.java
@@ -149,9 +149,7 @@ public class JsonLDExporter {
       images.add(imageAnnot);
       //If this list was somehow stored in the SQL DB, we could skip calling to the store every time. 
       otherContent = Canvas.getAnnotationListsForProject(projID, canvasID, u.getUID());
-      System.out.println("gathered image resource and other content...moving to checks");
       if(otherContent.length == 0){ //No list on store
-         System.out.println("Other content length 0.  Get annos, bulk save, save anno list...");
          try (Connection conn = getDBConnection()) {
          try (PreparedStatement stmt = conn.prepareStatement("SELECT * FROM transcription WHERE projectID = ? AND folio = ? ORDER BY x, y")) {
             stmt.setInt(1, projID);
@@ -195,7 +193,6 @@ public class JsonLDExporter {
         } 
       }
       else{ //could maybe break this else away, but make sure to set the otherContent field of result in the "if" if you do.
-          System.out.println("Found a list on the store, no need to update from sql. ");
           result.put("otherContent", otherContent);
       }
       result.put("images", images);

--- a/src/java/edu/slu/tpen/transfer/JsonLDExporter.java
+++ b/src/java/edu/slu/tpen/transfer/JsonLDExporter.java
@@ -41,6 +41,7 @@ import static edu.slu.util.LangUtils.buildQuickMap;
 import static edu.slu.util.ServletUtils.getDBConnection;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
+import textdisplay.Annotation;
 
 /**
  * Class which manages serialisation to JSON-LD. Builds a Map containing the
@@ -109,15 +110,15 @@ public class JsonLDExporter {
       JSONArray resources_array = new JSONArray();
       annotationList.element("@type", "sc:AnnotationList");
       annotationList.element("label", canvasID+" List");
-      annotationList.element("resources", resources_array);
       annotationList.element("proj", projID);
       annotationList.element("on", canvasID);
       annotationList.element("@context", "http://iiif.io/api/presentation/2/context.json");
+      //annotationList.element("testing", "msid_creation");
       //String canvasID = projName + "/canvas/" + URLEncoder.encode(f.getPageName(), "UTF-8");
-      Dimension pageDim = ImageCache.getImageDimension(f.getFolioNumber());
+      Dimension pageDim = f.getImageDimension();
       String[] otherContent;
       if (pageDim == null) {
-         LOG.log(Level.INFO, "Image for {0} not found in cache, loading image...", f.getFolioNumber());
+         //LOG.log(Level.INFO, "Image for {0} not found in cache, loading image...", f.getFolioNumber());
          pageDim = f.getImageDimension();
       }
       LOG.log(Level.INFO, "pageDim={0}", pageDim);
@@ -126,10 +127,8 @@ public class JsonLDExporter {
       result.put("@id", canvasID);
       result.put("@type", "sc:Canvas");
       result.put("label", f.getPageName());
-
       int canvasHeight = 1000;
       result.put("height", canvasHeight);
-      
       if (pageDim != null) {
          int canvasWidth = pageDim.width * canvasHeight / pageDim.height;  // Convert to canvas coordinates.
          result.put("width", canvasWidth);
@@ -139,7 +138,6 @@ public class JsonLDExporter {
       Map<String, Object> imageAnnot = new LinkedHashMap<>();
       imageAnnot.put("@type", "oa:Annotation");
       imageAnnot.put("motivation", "sc:painting");
-      
       Map<String, Object> imageResource = buildQuickMap("@id", String.format("%s%s&user=%s", Folio.getRbTok("SERVERURL"), f.getImageURLResize(), u.getUname()), "@type", "dctypes:Image", "format", "image/jpeg");
 //      imageResource.put("iiif", ?);
       if (pageDim != null) {
@@ -151,64 +149,55 @@ public class JsonLDExporter {
       images.add(imageAnnot);
       //If this list was somehow stored in the SQL DB, we could skip calling to the store every time. 
       otherContent = Canvas.getAnnotationListsForProject(projID, canvasID, u.getUID());
-      System.out.println("JSON exporter other content...");
-      System.out.println(otherContent.toString());
-      result.put("otherContent", otherContent);
+      System.out.println("gathered image resource and other content...moving to checks");
       if(otherContent.length == 0){ //No list on store
-          System.out.println("Need to gather lines off the sql, save them, add them to a list, and save the list to the store for the folios");
+         System.out.println("Other content length 0.  Get annos, bulk save, save anno list...");
          try (Connection conn = getDBConnection()) {
          try (PreparedStatement stmt = conn.prepareStatement("SELECT * FROM transcription WHERE projectID = ? AND folio = ? ORDER BY x, y")) {
             stmt.setInt(1, projID);
             stmt.setInt(2, f.getFolioNumber());
             ResultSet rs = stmt.executeQuery();
             while (rs.next()) {
-               // Body of the annotation.  Contains the actual text.
-/*            text = rs.getString("text");
-            comment = rs.getString("comment");
-            UID = rs.getInt("creator");
-            lineID = rs.getInt("id");
-            x = rs.getInt("x");
-            y = rs.getInt("y");
-            width = rs.getInt("width");
-            height = rs.getInt("height");
-            this.projectID = rs.getInt("projectID");
-            this.folio = rs.getInt("folio");
-            date = rs.getDate("date"); */
                int lineID = rs.getInt("id");
                Map<String, Object> lineAnnot = new LinkedHashMap<>();
                String lineURI = projName + "/line/" + lineID;
-               lineAnnot.put("@id", lineURI);
+               //lineAnnot.put("@id", lineURI);
+               lineAnnot.put("tpen_line_id", lineURI);
                lineAnnot.put("@type", "oa:Annotation");
-               lineAnnot.put("motivation", "sc:painting");
+               lineAnnot.put("motivation", "oad:transcribing"); 
                lineAnnot.put("resource", buildQuickMap("@type", "cnt:ContentAsText", "cnt:chars", ESAPI.encoder().decodeForHTML(rs.getString("text"))));
-               lineAnnot.put("on", String.format("%s#xywh=%d,%d,%d,%d", canvasID, rs.getInt("x"), rs.getInt("y"), rs.getInt("width"), rs.getInt("height")));
-               //TODO: Save the annotation, add the real @id field, add into resources
+               lineAnnot.put("on", String.format("%s#xywh=%d,%d,%d,%d", canvasID, rs.getInt("x"), rs.getInt("y"), rs.getInt("width"), rs.getInt("height")));               
                resources.add(lineAnnot);
 
                String note = rs.getString("comment");
                if (StringUtils.isNotBlank(note)) {
                   Map<String, Object> noteAnnot = new LinkedHashMap<>();
-                  noteAnnot.put("@id", projName + "/note/" + lineID);
+                  //noteAnnot.put("@id", projName + "/note/" + lineID);
                   noteAnnot.put("@type", "oa:Annotation");
                   noteAnnot.put("motivation", "oa:commenting");
                   noteAnnot.put("resource", buildQuickMap("@type", "cnt:ContentAsText", "cnt:chars", note));
-                  noteAnnot.put("on", lineURI);
+                  noteAnnot.put("on", lineURI); //TODO: should this be on an @id of an annotation? If so, that complicates how i want to do the bulk.
+                  //noteAnnot.put("testing", "msid_creation");
                   resources.add(noteAnnot);
                   //TODO: Save the annotation, add the real @id field, add into resources
                }
             }
             resources_array = JSONArray.fromObject(resources);
+            resources_array = Canvas.bulkSaveAnnotations(resources_array);
             annotationList.element("resources", resources_array);
+            String newListID = Annotation.saveNewAnnotationList(annotationList);
+            annotationList.element("@id", newListID);
+            otherContent = new String[1];
+            otherContent[0] = newListID;
+            result.put("otherContent", otherContent);
             //TODO: Save this annotation list into the annotation store.  otherContent = ["new_@id_created_by_save"]; result.put("otherContent", otherContent);!
          }
         } 
       }
       else{ //could maybe break this else away, but make sure to set the otherContent field of result in the "if" if you do.
-          System.out.println("Found a list on the store, no need to update from sql");
+          System.out.println("Found a list on the store, no need to update from sql. ");
+          result.put("otherContent", otherContent);
       }
-      // lineID, textUnencoded, x, y, width, height, comment
-      // TODO: we don't want to put the resources array here anymore if there is an annotation list in otherContent. 
-      result.put("resources", resources);
       result.put("images", images);
       return result;
    }

--- a/src/java/edu/slu/tpen/transfer/JsonLDExporter.java
+++ b/src/java/edu/slu/tpen/transfer/JsonLDExporter.java
@@ -113,15 +113,15 @@ public class JsonLDExporter {
       annotationList.element("proj", projID);
       annotationList.element("on", canvasID);
       annotationList.element("@context", "http://iiif.io/api/presentation/2/context.json");
-      //annotationList.element("testing", "msid_creation");
+      annotationList.element("testing", "msid_creation");
       //String canvasID = projName + "/canvas/" + URLEncoder.encode(f.getPageName(), "UTF-8");
-      Dimension pageDim = ImageCache.getImageDimension(f.getFolioNumber());
+      //Dimension pageDim = ImageCache.getImageDimension(f.getFolioNumber());
       String[] otherContent;
-      if (pageDim == null) {
-         //LOG.log(Level.INFO, "Image for {0} not found in cache, loading image...", f.getFolioNumber());
-         pageDim = f.getImageDimension();
-      }
-      LOG.log(Level.INFO, "pageDim={0}", pageDim);
+//      if (pageDim == null) {
+//         //LOG.log(Level.INFO, "Image for {0} not found in cache, loading image...", f.getFolioNumber());
+//         pageDim = f.getImageDimension();
+//      }
+//      LOG.log(Level.INFO, "pageDim={0}", pageDim);
 
       Map<String, Object> result = new LinkedHashMap<>();
       result.put("@id", canvasID);
@@ -129,10 +129,10 @@ public class JsonLDExporter {
       result.put("label", f.getPageName());
       int canvasHeight = 1000;
       result.put("height", canvasHeight);
-      if (pageDim != null) {
-         int canvasWidth = pageDim.width * canvasHeight / pageDim.height;  // Convert to canvas coordinates.
-         result.put("width", canvasWidth);
-      }
+//      if (pageDim != null) {
+//         int canvasWidth = pageDim.width * canvasHeight / pageDim.height;  // Convert to canvas coordinates.
+//         result.put("width", canvasWidth);
+//      }
       List<Object> resources = new ArrayList<>();
       List<Object> images = new ArrayList<>();
       Map<String, Object> imageAnnot = new LinkedHashMap<>();
@@ -140,10 +140,10 @@ public class JsonLDExporter {
       imageAnnot.put("motivation", "sc:painting");
       Map<String, Object> imageResource = buildQuickMap("@id", String.format("%s%s&user=%s", Folio.getRbTok("SERVERURL"), f.getImageURLResize(), u.getUname()), "@type", "dctypes:Image", "format", "image/jpeg");
 //      imageResource.put("iiif", ?);
-      if (pageDim != null) {
-         imageResource.put("height", pageDim.height);
-         imageResource.put("width", pageDim.width);
-      }
+     // if (pageDim != null) {
+         imageResource.put("height", 2000 ); //pageDim.height
+         imageResource.put("width", 1600 ); //pageDim.width
+     // }
       imageAnnot.put("resource", imageResource);
       imageAnnot.put("on", canvasID);
       images.add(imageAnnot);
@@ -163,8 +163,10 @@ public class JsonLDExporter {
                lineAnnot.put("tpen_line_id", lineURI);
                lineAnnot.put("@type", "oa:Annotation");
                lineAnnot.put("motivation", "oad:transcribing"); 
-               lineAnnot.put("resource", buildQuickMap("@type", "cnt:ContentAsText", "cnt:chars", ESAPI.encoder().decodeForHTML(rs.getString("text"))));
-               lineAnnot.put("on", String.format("%s#xywh=%d,%d,%d,%d", canvasID, rs.getInt("x"), rs.getInt("y"), rs.getInt("width"), rs.getInt("height")));               
+               lineAnnot.put("resource", buildQuickMap("@type", "cnt:ContentAsText", "cnt:chars", rs.getString("text")));
+               // ^ESAPI.encoder().decodeForHTML(rs.getString("text"))
+               lineAnnot.put("on", String.format("%s#xywh=%d,%d,%d,%d", canvasID, rs.getInt("x"), rs.getInt("y"), rs.getInt("width"), rs.getInt("height"))); 
+               lineAnnot.put("testing", "msid_creation");
                resources.add(lineAnnot);
 
                String note = rs.getString("comment");
@@ -175,7 +177,7 @@ public class JsonLDExporter {
                   noteAnnot.put("motivation", "oa:commenting");
                   noteAnnot.put("resource", buildQuickMap("@type", "cnt:ContentAsText", "cnt:chars", note));
                   noteAnnot.put("on", lineURI); //TODO: should this be on an @id of an annotation? If so, that complicates how i want to do the bulk.
-                  //noteAnnot.put("testing", "msid_creation");
+                  noteAnnot.put("testing", "msid_creation");
                   resources.add(noteAnnot);
                   //TODO: Save the annotation, add the real @id field, add into resources
                }

--- a/src/java/textdisplay/Annotation.java
+++ b/src/java/textdisplay/Annotation.java
@@ -330,7 +330,7 @@ DatabaseWrapper.closePreparedStatement(ps);
      @return: The @id of the newly saved anntoationList
    */
    public static String saveNewAnnotationList(JSONObject annotationListObject) throws MalformedURLException, IOException{
-       String newListID = "";
+        String newListID = "";
         URL postUrl = new URL(Constant.ANNOTATION_SERVER_ADDR + "/anno/saveNewAnnotation.action");
         HttpURLConnection connection = (HttpURLConnection) postUrl.openConnection();
         connection.setDoOutput(true);

--- a/src/java/textdisplay/Annotation.java
+++ b/src/java/textdisplay/Annotation.java
@@ -11,6 +11,15 @@ and limitations under the License.
  */
 package textdisplay;
 
+import edu.slu.tpen.servlet.Constant;
+import java.io.BufferedReader;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLEncoder;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -18,6 +27,8 @@ import java.sql.SQLException;
 import java.util.Stack;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import net.sf.json.JSONException;
+import net.sf.json.JSONObject;
 import org.owasp.esapi.ESAPI;
 
 /**
@@ -310,4 +321,44 @@ DatabaseWrapper.closePreparedStatement(ps);
     }
     return toret;
 }
+   
+   /*
+   * Used in the JSONLDExporter, specifically in a situation to help support old annotations and transfer them over
+     to the annotation store.  This essentially functions like a servlet.  
+     
+     @param annotationListObject: A well formed JSONObject that is an annotationList to be saved to the store.
+     @return: The @id of the newly saved anntoationList
+   */
+   public static String saveNewAnnotationList(JSONObject annotationListObject) throws MalformedURLException, IOException{
+       String newListID = "";
+        URL postUrl = new URL(Constant.ANNOTATION_SERVER_ADDR + "/anno/saveNewAnnotation.action");
+        HttpURLConnection connection = (HttpURLConnection) postUrl.openConnection();
+        connection.setDoOutput(true);
+        connection.setDoInput(true);
+        connection.setRequestMethod("POST");
+        connection.setUseCaches(false);
+        connection.setInstanceFollowRedirects(true);
+        connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+        connection.connect();
+        DataOutputStream out = new DataOutputStream(connection.getOutputStream()); 
+        out.writeBytes("content=" + URLEncoder.encode(annotationListObject.toString(), "utf-8"));
+        out.flush();
+        out.close(); // flush and close
+        BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream(),"utf-8"));
+        String line="";
+        StringBuilder sb = new StringBuilder();
+        while ((line = reader.readLine()) != null){  
+            sb.append(line);
+        } 
+        reader.close();
+        connection.disconnect();
+        JSONObject server_response = JSONObject.fromObject(sb.toString());
+        try{
+           newListID = server_response.getString("@id");
+        }
+        catch(JSONException e){
+           newListID = "/id/gather/error";
+        }
+        return newListID;
+   }
 }


### PR DESCRIPTION
The JSONLDExporter will check if annotations exist on the folios of the project in the annotation store yet.  If they do not, it will check in the sql database transcription table for lines.  If it finds lines, it will bulk save them and pass the response list to an annotationList objects resources field.  That annotation list object will then be saved, thus getting the old TPEN transcription data into the annotation store and connected it to its canvas for its project.  

You will notice pageDim is commented out in the exporter. This is because in our test database, imageCache does not exist and that uses imageCache to build those parameters.  I have turned it off for now to avoid the errors, the T-PEN live databse will have that table (I am not sure if we still need to support that though?).