### PR TITLE
2.8 isAdmin hotfix

### DIFF
--- a/src/java/edu/slu/tpen/servlet/GetProjectTPENServlet.java
+++ b/src/java/edu/slu/tpen/servlet/GetProjectTPENServlet.java
@@ -198,6 +198,7 @@ public class GetProjectTPENServlet extends HttpServlet {
                                 }
                             }
                             jsonMap.put("ls_leader", gson.toJson(leaders));
+                            jsonMap.put("isTPENAdmin", isTPENAdmin+"");
                             //get project permission
                             //get project buttons
                             Hotkey hk = new Hotkey();

--- a/web/js/transcribe.js
+++ b/web/js/transcribe.js
@@ -579,6 +579,10 @@ function populateXML() {
 
 function setTPENObjectData(data) {
     if (data.project) {
+        if(data.isTPENAdmin && data.isTPENAdmin === "true"){
+            tpen.user.isAdmin = true;
+            tpen.user.isMember = tpen.user.isAdmin;
+        }
         if (data.projectTool) {
             try {
                 tpen.project.tools = JSON.parse(data.projectTool);


### PR DESCRIPTION
If you are not a member of the project and not a leader of the project then you cannot line parse in the 2.8 interface.  Detection on the back end is now passed forward so admins in the table are respected.