### PR TITLE
Get All Dunbar Projects

### DIFF
--- a/src/java/edu/slu/tpen/servlet/GetDunbarProjectsList.java
+++ b/src/java/edu/slu/tpen/servlet/GetDunbarProjectsList.java
@@ -58,22 +58,15 @@ public class GetDunbarProjectsList extends HttpServlet {
                     String pattern2 = "_";
                     String pattern3 = ".jpg";
                     String regexString1 = Pattern.quote(pattern1) + "(.*?)" + Pattern.quote(pattern2);
-                    String regexString2 = Pattern.quote(pattern1) + "(.*?)" + Pattern.quote(pattern3);
                     Pattern patternA = Pattern.compile(regexString1);
-                    Pattern patternB = Pattern.compile(regexString2);
                     Matcher matcherA = patternA.matcher(fp.getPageName());
-                    Matcher matcherB = patternB.matcher(fp.getPageName());
                     String shortCode = "";
                     String longCode = "";
                     if (matcherA.find()) {
                         shortCode = matcherA.group(1); // Since (.*?) is capturing group 1
                     }
-                    if (matcherB.find()) {
-                        longCode = matcherB.group(1); // Since (.*?) is capturing group 1
-                    }
                     String delShort = "F"+shortCode;
-                    String delLong = "F"+longCode;
-                    result.add(buildQuickMap("id", ""+p.getProjectID(), "name", p.getProjectName(), "short", delShort, "long", delLong));
+                    result.add(buildQuickMap("id", ""+p.getProjectID(), "project_name", p.getName(), "metadata_name", p.getProjectName(), "code", delShort));
               }
               ObjectMapper mapper = new ObjectMapper();
               mapper.writeValue(response.getOutputStream(), result);

--- a/src/java/edu/slu/tpen/servlet/GetDunbarProjectsList.java
+++ b/src/java/edu/slu/tpen/servlet/GetDunbarProjectsList.java
@@ -1,0 +1,105 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/JSP_Servlet/Servlet.java to edit this template
+ */
+package edu.slu.tpen.servlet;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import static edu.slu.util.LangUtils.buildQuickMap;
+import static edu.slu.util.ServletUtils.getUID;
+import static edu.slu.util.ServletUtils.reportInternalError;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+import textdisplay.Project;
+import user.User;
+
+/**
+ *
+ * @author bhaberbe
+ */
+public class GetDunbarProjectsList extends HttpServlet {
+
+    /**
+     * Processes requests for both HTTP <code>GET</code> and <code>POST</code>
+     * methods.
+     *
+     * @param request servlet request
+     * @param response servlet response
+     * @throws ServletException if a servlet-specific error occurs
+     * @throws IOException if an I/O error occurs
+     */
+    protected void processRequest(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        response.setContentType("text/html;charset=UTF-8");
+        int uid = getUID(request, response);
+        if (uid > 0) {
+           response.setContentType("application/json");
+           try {
+              User u = new User(uid);
+              Project[] projs = Project.getAllDunbarProjects();
+              List<Map<String, Object>> result = new ArrayList<>();
+              for (Project p: projs) {
+                 result.add(buildQuickMap("id", ""+p.getProjectID(), "name", p.getProjectName()));
+              }
+              ObjectMapper mapper = new ObjectMapper();
+              mapper.writeValue(response.getOutputStream(), result);
+           } catch (SQLException ex) {
+              reportInternalError(response, ex);
+              response.sendError(SC_INTERNAL_SERVER_ERROR, ex.getMessage());
+           }
+        } 
+        else {
+            response.sendError(SC_UNAUTHORIZED);
+        }
+    }
+
+    // <editor-fold defaultstate="collapsed" desc="HttpServlet methods. Click on the + sign on the left to edit the code.">
+    /**
+     * Handles the HTTP <code>GET</code> method.
+     *
+     * @param request servlet request
+     * @param response servlet response
+     * @throws ServletException if a servlet-specific error occurs
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        processRequest(request, response);
+    }
+
+    /**
+     * Handles the HTTP <code>POST</code> method.
+     *
+     * @param request servlet request
+     * @param response servlet response
+     * @throws ServletException if a servlet-specific error occurs
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        processRequest(request, response);
+    }
+
+    /**
+     * Returns a short description of the servlet.
+     *
+     * @return a String containing servlet description
+     */
+    @Override
+    public String getServletInfo() {
+        return "Short description";
+    }// </editor-fold>
+
+}

--- a/src/java/textdisplay/Project.java
+++ b/src/java/textdisplay/Project.java
@@ -615,12 +615,12 @@ public class Project {
      * @throws java.sql.SQLException
      */
     public static Project[] getAllDunbarProjects() throws SQLException {
-        String query = "select distinct(project.id) from project where project.name "
-                + "like 'F-%' or "
-                + "like '%letter%' or "
-                + "like '%telegram%' or "
-                + "like '%envelope%' or "
-                + "like '%poem%' "
+        String query = "select distinct(project.id) from project where "
+                + "project.name like 'F-%' or "
+                + "project.name like '%letter%' or "
+                + "project.name like '%telegram%' or "
+                + "project.name like '%envelope%' or "
+                + "project.name like '%poem%' "
                 + "order by project.name desc";
         Connection j = null;
         PreparedStatement ps = null;

--- a/src/java/textdisplay/Project.java
+++ b/src/java/textdisplay/Project.java
@@ -264,6 +264,10 @@ public class Project {
     public int getProjectID() {
         return projectID;
     }
+    
+    public String getName() {
+        return projectName;
+    }
 
     /**
      * Update the Project image sequence

--- a/src/java/textdisplay/Project.java
+++ b/src/java/textdisplay/Project.java
@@ -616,7 +616,9 @@ public class Project {
      */
     public static Project[] getAllDunbarProjects() throws SQLException {
         String query = "select distinct(project.id) from project where "
-                + "project.name like 'F-%' or "
+                //+ "project.name like 'F-_%-_% ' or " //F-ne-nenbsp;blah
+                + "project.name like 'F-%' or " //F followed by hyphen then anything
+                + "project.name like 'F#%' or " //F followed by a number then anything
                 + "project.name like '%letter%' or "
                 + "project.name like '%telegram%' or "
                 + "project.name like '%envelope%' or "

--- a/src/java/textdisplay/Project.java
+++ b/src/java/textdisplay/Project.java
@@ -616,13 +616,14 @@ public class Project {
      */
     public static Project[] getAllDunbarProjects() throws SQLException {
         String query = "select distinct(project.id) from project where "
+                + "project.name like '% DLA %' "
                 //+ "project.name like 'F-_%-_% ' or " //F-ne-nenbsp;blah
-                + "project.name like 'F-%' or " //F followed by hyphen then anything
-                + "project.name like 'F#%' or " //F followed by a number then anything
-                + "project.name like '%letter%' or "
-                + "project.name like '%telegram%' or "
-                + "project.name like '%envelope%' or "
-                + "project.name like '%poem%' "
+                //+ "project.name like 'F-%' or " //F followed by hyphen then anything
+                //+ "project.name like 'F#%' or " //F followed by a number then anything
+                //+ "project.name like '%letter%' or "
+                //+ "project.name like '%telegram%' or "
+                //+ "project.name like '%envelope%' or "
+                //+ "project.name like '%poem%' "
                 + "order by project.name desc";
         Connection j = null;
         PreparedStatement ps = null;

--- a/src/java/textdisplay/Project.java
+++ b/src/java/textdisplay/Project.java
@@ -620,7 +620,7 @@ public class Project {
                 + "like '%letter%' or "
                 + "like '%telegram%' or "
                 + "like '%envelope%' or "
-                + "like '%poem%' or "
+                + "like '%poem%' "
                 + "order by project.name desc";
         Connection j = null;
         PreparedStatement ps = null;

--- a/src/java/textdisplay/Project.java
+++ b/src/java/textdisplay/Project.java
@@ -618,9 +618,9 @@ public class Project {
         String query = "select distinct(project.id) from project where project.name "
                 + "like 'F-%' or "
                 + "like '%letter%' or "
-                + "like '%telegram%' or"
-                + "like '%envelope%' or"
-                + "like '%poem%' or"
+                + "like '%telegram%' or "
+                + "like '%envelope%' or "
+                + "like '%poem%' or "
                 + "order by project.name desc";
         Connection j = null;
         PreparedStatement ps = null;

--- a/src/java/textdisplay/Project.java
+++ b/src/java/textdisplay/Project.java
@@ -606,6 +606,45 @@ public class Project {
             closePreparedStatement(ps);
         }
     }
+    
+    /**
+     * Get all Projects that are connected with the DLA projects.
+     * They should all have titles like 
+     *
+     * @return
+     * @throws java.sql.SQLException
+     */
+    public static Project[] getAllDunbarProjects() throws SQLException {
+        String query = "select distinct(project.id) from project where project.name "
+                + "like 'F-%' or "
+                + "like '%letter%' or "
+                + "like '%telegram%' or"
+                + "like '%envelope%' or"
+                + "like '%poem%' or"
+                + "order by project.name desc";
+        Connection j = null;
+        PreparedStatement ps = null;
+        try {
+            j = getConnection();
+            ps = j.prepareStatement(query);
+
+            ResultSet rs = ps.executeQuery();
+            Stack<Integer> projectIDs = new Stack();
+            while (rs.next()) {
+                projectIDs.push(rs.getInt("project.id"));
+            }
+            Project[] toret = new Project[projectIDs.size()];
+            int ctr = 0;
+            while (!projectIDs.empty()) {
+                toret[ctr] = new Project(projectIDs.pop());
+                ctr++;
+            }
+            return toret;
+        } finally {
+            closeDBConnection(j);
+            closePreparedStatement(ps);
+        }
+    }
 
     /**
      * Get all projects ordered by project name

--- a/web/WEB-INF/web.xml
+++ b/web/WEB-INF/web.xml
@@ -251,6 +251,10 @@
         <servlet-name>updateXMLEntries</servlet-name>
         <servlet-class>servlets.updateXMLEntries</servlet-class>
     </servlet>
+    <servlet>
+        <servlet-name>GetDunbarProjectsList</servlet-name>
+        <servlet-class>edu.slu.tpen.servlet.GetDunbarProjectsList</servlet-class>
+    </servlet>
     <servlet-mapping>
         <servlet-name>imageResize</servlet-name>
         <url-pattern>/imageResize</url-pattern>
@@ -684,6 +688,10 @@
     <servlet-mapping>
         <servlet-name>updateXMLEntries</servlet-name>
         <url-pattern>/updateXMLEntries</url-pattern>
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>GetDunbarProjectsList</servlet-name>
+        <url-pattern>/getDunbarProjects</url-pattern>
     </servlet-mapping>
     <session-config>
         <!-- In minutes -->


### PR DESCRIPTION
A public servlet that returns a list of DLA projects.  User must be logged in to use this. 

Magic ask is
`select distinct(project.id) from project where project.name like '% DLA %' "`
Each of those is made into a project object and return to the servlet logic.
The servlet logic pairs `{"id":4080. "name": "Tradamus Simple"}` for each project
The servlet logic has access to all metadata columns and project columns, should we want it to be more robust then we just add more to that map that is built for the return.

exposed through `/TPEN/getDunbarProjects`