### PR TITLE
Ong and RCG Rhetoric for t-pen.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 The Transcription for Paleographical and Editorial Notation (T‑PEN) project was coordinated by the Center for Digital Theology at Saint Louis University (SLU) and funded by the Andrew W. Mellon Foundation and the NEH. The Electronic Norman Anonymous Project developed several abilities at the core of this project's functionality.
 
-T-PEN is currently (2022) maintained by the Research Computing Group at Saint Louis University.  T-PEN is no longer funded.
+T-PEN is currently (2022) maintained by the Research Computing Group at Saint Louis University.
 
 T‑PEN is released under ECL v.2.0 as free and open-source software (git), the primary instance of which is maintained by SLU at T‑PEN.org.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # TPEN28
 ![](http://t-pen.org/TPEN/images/tpen_logo_header.jpg)
 
-The Transcription for Paleographical and Editorial Notation (T‑PEN) project is coordinated by the Center for Digital Theology at Saint Louis University (SLU) and funded by the Andrew W. Mellon Foundation and the NEH. The Electronic Norman Anonymous Project developed several abilities at the core of this project's functionality.
+The Transcription for Paleographical and Editorial Notation (T‑PEN) project was coordinated by the Center for Digital Theology at Saint Louis University (SLU) and funded by the Andrew W. Mellon Foundation and the NEH. The Electronic Norman Anonymous Project developed several abilities at the core of this project's functionality.
+
+T-PEN is currently (2022) maintained by the Research Computing Group at Saint Louis University.  T-PEN is no longer funded.
 
 T‑PEN is released under ECL v.2.0 as free and open-source software (git), the primary instance of which is maintained by SLU at T‑PEN.org.
 

--- a/web/about.jsp
+++ b/web/about.jsp
@@ -115,7 +115,7 @@
                             <dl>                                
                                 <dt>Patrick Cuba, I.T. Architect</dt>
                                 <dd>Research Computing Group, Saint Louis University</dd>
-                                <dt>Bryan Haberberger, Full Stack Developerr</dt>
+                                <dt>Bryan Haberberger, Full Stack Developer</dt>
                                 <dd>Research Computing Group, Saint Louis University</dd>
                             </dl>
                         </li>

--- a/web/about.jsp
+++ b/web/about.jsp
@@ -113,18 +113,10 @@
                         <li class="gui-tab-section">
                             <h3>Support/Maintenance Team <br> T-PEN 2.0-2.8</h3>
                             <dl>                                
-                                <dt>Dr. Jim Ginther, Principal Investigator</dt>
-                                <dd>Director, Center&nbsp;for&nbsp;Digital&nbsp;Theology, Saint&nbsp;Louis&nbsp;University</dd>
-                                <dt>Dr. Thomas Finan, Principal Investigator (2016-present)</dt>
-                                <dd>Director, Walter J. Ong S.J. Center for Digital Humanities, Saint Louis University</dd>
-                                <dt>Donal Hegarty, Project Manager/UX Designer</dt>
-                                <dd>Walter J. Ong S.J. Center for Digital Humanities, Saint Louis University</dd>
-                                <dt>Patrick Cuba, Lead Developer</dt>
-                                <dd>Walter J. Ong S.J. Center for Digital Humanities, Saint Louis University</dd>
-                                <dt>Bryan Haberberger, Web Developer</dt>
-                                <dd>Walter J. Ong S.J. Center for Digital Humanities, Saint Louis University</dd>
-                                <dt>Han Yan, Web Developer</dt>
-                                <dd>Walter J. Ong S.J. Center for Digital Humanities, Saint Louis University</dd>
+                                <dt>Patrick Cuba, I.T. Architect</dt>
+                                <dd>Research Computing Group, Saint Louis University</dd>
+                                <dt>Bryan Haberberger, Full Stack Developerr</dt>
+                                <dd>Research Computing Group, Saint Louis University</dd>
                             </dl>
                         </li>
                         <li class="gui-tab-section">
@@ -144,8 +136,8 @@
                                 <dd>University&nbsp;of&nbsp;Kentucky</dd>
                                 <dt>Jon Deering, Senior Developer</dt>
                                 <dd>Center&nbsp;for&nbsp;Digital&nbsp;Theology, Saint&nbsp;Louis&nbsp;University</dd>
-                                <dt>Patrick Cuba, Web Developer</dt>
-                                <dd>Center&nbsp;for&nbsp;Digital&nbsp;Theology, Saint&nbsp;Louis&nbsp;University</dd>
+                                <dt>Patrick Cuba, I.T. Architect</dt>
+                                <dd>Research Computing Group, Saint Louis University</dd>
                             </dl>
                         </li>
                         <li class="gui-tab-section">

--- a/web/about.jsp
+++ b/web/about.jsp
@@ -36,7 +36,7 @@
                             <h3>T&#8209;PEN</h3>
                             <p>The Transcription for Paleographical and Editorial Notation (T&#8209;PEN) project was coordinated by the <a href="http://www.slu.edu/x27122.xml" target="_blank">Center for Digital Theology</a> at <a href="www.slu.edu" target="_blank">Saint Louis University</a> (SLU) and funded by the <a href="http://www.mellon.org/" target="_blank">Andrew W. Mellon Foundation</a> and the <a title="National Endowment for the Humanities" target="_blank" href="http://www.neh.gov/">NEH</a>. The <a target="_blank" href="ENAP/">Electronic Norman Anonymous Project</a> developed several abilities at the core of this project's functionality.</p>
                             <p>T&#8209;PEN is released under <a href="http://www.opensource.org/licenses/ecl2.php" title="Educational Community License" target="_blank">ECL v.2.0</a> as free and open-source software (<a href="https://github.com/jginther/T-PEN/tree/master/trunk" target="_blank">git</a>), the primary instance of which is maintained by SLU at <a href="www.T&#8209;PEN.org" target="_blank">T&#8209;PEN.org</a>.
-                            <p>T&#8209;PEN is currently (2022) maintained by the Research Computing Group at Saint Louis University and is no longer funded.</p>    
+                            <p>T&#8209;PEN is currently (2022) maintained by the Research Computing Group at Saint Louis University.</p>    
                         </li>
                         <li class="gui-tab-section" style="background-image:url(./images/trexhead.png);">
                         </li>
@@ -113,7 +113,7 @@
                         <li class="gui-tab-section">
                             <h3>Support/Maintenance Team <br> T-PEN 2.8-3.0</h3>
                             <dl>                                
-                                <dt>Patrick Cuba, I.T. Architect</dt>
+                                <dt>Patrick Cuba, IT Architect</dt>
                                 <dd>Research Computing Group, Saint Louis University</dd>
                                 <dt>Bryan Haberberger, Full Stack Developer</dt>
                                 <dd>Research Computing Group, Saint Louis University</dd>
@@ -153,7 +153,7 @@
                                 <dd>University&nbsp;of&nbsp;Kentucky</dd>
                                 <dt>Jon Deering, Senior Developer</dt>
                                 <dd>Center&nbsp;for&nbsp;Digital&nbsp;Theology, Saint&nbsp;Louis&nbsp;University</dd>
-                                <dt>Patrick Cuba, I.T. Architect</dt>
+                                <dt>Patrick Cuba, Web Developer</dt>
                                 <dd>Research Computing Group, Saint Louis University</dd>
                             </dl>
                         </li>

--- a/web/about.jsp
+++ b/web/about.jsp
@@ -34,9 +34,9 @@
                     <ul id="about">
                         <li class="gui-tab-section">
                             <h3>T&#8209;PEN</h3>
-                            <p>The Transcription for Paleographical and Editorial Notation (T&#8209;PEN) project is coordinated by the <a href="http://www.slu.edu/x27122.xml" target="_blank">Center for Digital Theology</a> at <a href="www.slu.edu" target="_blank">Saint Louis University</a> (SLU) and funded by the <a href="http://www.mellon.org/" target="_blank">Andrew W. Mellon Foundation</a> and the <a title="National Endowment for the Humanities" target="_blank" href="http://www.neh.gov/">NEH</a>. The <a target="_blank" href="ENAP/">Electronic Norman Anonymous Project</a> developed several abilities at the core of this project's functionality.</p>
+                            <p>The Transcription for Paleographical and Editorial Notation (T&#8209;PEN) project was coordinated by the <a href="http://www.slu.edu/x27122.xml" target="_blank">Center for Digital Theology</a> at <a href="www.slu.edu" target="_blank">Saint Louis University</a> (SLU) and funded by the <a href="http://www.mellon.org/" target="_blank">Andrew W. Mellon Foundation</a> and the <a title="National Endowment for the Humanities" target="_blank" href="http://www.neh.gov/">NEH</a>. The <a target="_blank" href="ENAP/">Electronic Norman Anonymous Project</a> developed several abilities at the core of this project's functionality.</p>
                             <p>T&#8209;PEN is released under <a href="http://www.opensource.org/licenses/ecl2.php" title="Educational Community License" target="_blank">ECL v.2.0</a> as free and open-source software (<a href="https://github.com/jginther/T-PEN/tree/master/trunk" target="_blank">git</a>), the primary instance of which is maintained by SLU at <a href="www.T&#8209;PEN.org" target="_blank">T&#8209;PEN.org</a>.
-                            </p>
+                            <p>T&#8209;PEN is currently (2022) maintained by the Research Computing Group at Saint Louis University and is no longer funded.</p>    
                         </li>
                         <li class="gui-tab-section" style="background-image:url(./images/trexhead.png);">
                         </li>

--- a/web/about.jsp
+++ b/web/about.jsp
@@ -111,12 +111,29 @@
                             <p>  </p>
                         </li>
                         <li class="gui-tab-section">
-                            <h3>Support/Maintenance Team <br> T-PEN 2.0-2.8</h3>
+                            <h3>Support/Maintenance Team <br> T-PEN 2.8-3.0</h3>
                             <dl>                                
                                 <dt>Patrick Cuba, I.T. Architect</dt>
                                 <dd>Research Computing Group, Saint Louis University</dd>
                                 <dt>Bryan Haberberger, Full Stack Developer</dt>
                                 <dd>Research Computing Group, Saint Louis University</dd>
+                            </dl>
+                        </li>
+                        <li class="gui-tab-section">
+                            <h3>Support/Maintenance Team <br> T-PEN 2.0-2.8</h3>
+                            <dl>                                
+                                <dt>Dr. Jim Ginther, Principal Investigator</dt>
+                                <dd>Director, Center&nbsp;for&nbsp;Digital&nbsp;Theology, Saint&nbsp;Louis&nbsp;University</dd>
+                                <dt>Dr. Thomas Finan, Principal Investigator (2016-present)</dt>
+                                <dd>Director, Walter J. Ong S.J. Center for Digital Humanities, Saint Louis University</dd>
+                                <dt>Donal Hegarty, Project Manager/UX Designer</dt>
+                                <dd>Walter J. Ong S.J. Center for Digital Humanities, Saint Louis University</dd>
+                                <dt>Patrick Cuba, Lead Developer</dt>
+                                <dd>Walter J. Ong S.J. Center for Digital Humanities, Saint Louis University</dd>
+                                <dt>Bryan Haberberger, Web Developer</dt>
+                                <dd>Walter J. Ong S.J. Center for Digital Humanities, Saint Louis University</dd>
+                                <dt>Han Yan, Web Developer</dt>
+                                <dd>Walter J. Ong S.J. Center for Digital Humanities, Saint Louis University</dd>
                             </dl>
                         </li>
                         <li class="gui-tab-section">

--- a/web/js/transcribe.js
+++ b/web/js/transcribe.js
@@ -7066,7 +7066,7 @@ function dailyTip() {
         "Export your project as a SharedCanvas Manifest to use it in other great IIIF tools.",
         "You can find your project's T&#8209;PEN I.D. by managing your project.  It is also often in your browser's address bar! ",
         "Access the SharedCanvas Manifest for your project any time by going to http://t-pen.org/TPEN/manifest/{projectID}",
-        "The Walter J. Ong, SJ Center for Digital Humanities at Saint Louis University thanks you for using T&#8209;PEN.",
+        "The Research Computing Group at Saint Louis University thanks you for using T&#8209;PEN.",
         "Need a closer look?  Try using the Inspect tool!",
         "Visit the blog for news on TPEN3!"
     ];


### PR DESCRIPTION
Swap out or combine the mentions of Digital Humanities and Research Computing Group in page text.