### PR TITLE
Adding `buildPage` for  version 3 manifests

### DIFF
--- a/src/java/edu/slu/tpen/servlet/CanvasServlet.java
+++ b/src/java/edu/slu/tpen/servlet/CanvasServlet.java
@@ -59,10 +59,10 @@ public class CanvasServlet extends HttpServlet{
 
                     if (req.getHeader("Accept") != null && req.getHeader("Accept").contains("iiif/v3")) {
                         resp.setHeader("Content-Type", "application/ld+json;profile=\"http://iiif.io/api/presentation/3/context.json\"");
-                        resp.getWriter().write(export(JsonHelper.buildPage(f, "v3")));
+                        resp.getWriter().write(export((JSONObject) JsonHelper.buildPage(f, "v3")));
                     }
                     else {
-                        resp.getWriter().write(export(JsonHelper.buildPage(f)));
+                        resp.getWriter().write(export((JSONObject) JsonHelper.buildPage(f)));
                     }
                     resp.setStatus(SC_OK);
                 } else {

--- a/src/java/edu/slu/tpen/servlet/CanvasServlet.java
+++ b/src/java/edu/slu/tpen/servlet/CanvasServlet.java
@@ -7,18 +7,10 @@ package edu.slu.tpen.servlet;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import static edu.slu.util.LangUtils.buildQuickMap;
-import static imageLines.ImageCache.getImageDimension;
-import java.awt.Dimension;
 import java.io.IOException;
 import static java.lang.Integer.parseInt;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.logging.Level;
-import static java.util.logging.Level.INFO;
 import static java.util.logging.Level.SEVERE;
 import java.util.logging.Logger;
 import static java.util.logging.Logger.getLogger;
@@ -28,13 +20,9 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
-import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import textdisplay.Folio;
-import static textdisplay.Folio.getRbTok;
-import textdisplay.FolioDims;
-import static textdisplay.FolioDims.createFolioDimsRecord;
-import static utils.JsonHelper.buildNoneLanguageMap;
+import utils.*;
 
 
 /**
@@ -71,10 +59,10 @@ public class CanvasServlet extends HttpServlet{
 
                     if (req.getHeader("Accept") != null && req.getHeader("Accept").contains("iiif/v3")) {
                         resp.setHeader("Content-Type", "application/ld+json;profile=\"http://iiif.io/api/presentation/3/context.json\"");
-                        resp.getWriter().write(export(buildPage(f, "v3")));
+                        resp.getWriter().write(export(JsonHelper.buildPage(f, "v3")));
                     }
                     else {
-                        resp.getWriter().write(export(buildPage(f)));
+                        resp.getWriter().write(export(JsonHelper.buildPage(f)));
                     }
                     resp.setStatus(SC_OK);
                 } else {
@@ -114,145 +102,6 @@ public class CanvasServlet extends HttpServlet{
         return "T-PEN Canvas Dereferencer";
     }
     
-    /*
-        build the JSON representation of a canvas and return it.  It will not know about the project, so otherContent will contains all annotation lists this canvas
-        has across all projects.  It will ignore all user checks so as to be open.  
-    */
-     private JSONObject buildPage(Folio f) throws SQLException, IOException {
-         
-     try{
-            String canvasID = getRbTok("SERVERURL")+"canvas/"+f.getFolioNumber();
-            FolioDims pageDim = new FolioDims(f.getFolioNumber(), true);
-            Dimension storedDims = null;
-            JSONArray otherContent;
-            if (pageDim.getImageHeight() <= 0) { //There was no foliodim entry
-               storedDims = getImageDimension(f.getFolioNumber());
-               if(null == storedDims || storedDims.height <=0){ //There was no imagecache entry or a bad one we can't use
-                  // System.out.println("Need to resolve image headers for dimensions");
-                  storedDims = f.getImageDimension(); //Resolve the image headers and get the image dimensions
-               }
-            }
-            LOG.log(INFO, "pageDim={0}", pageDim);
-            JSONObject result  = new JSONObject();
-            //Map<String, Object> result = new LinkedHashMap<>();
-            result.put("@context","http://iiif.io/api/presentation/2/context.json");
-            result.put("@id", canvasID);
-            result.put("@type", "sc:Canvas");
-            result.put("label", f.getPageName());
-            int canvasHeight = pageDim.getCanvasHeight();
-            int canvasWidth = pageDim.getCanvasWidth();
-            if (storedDims != null) {//Then we were able to resolve image headers and we have good values to run this code block
-                  if(storedDims.height > 0){//The image header resolved to 0, so actually we have bad values.
-                      if(pageDim.getImageHeight() <= 0){ //There was no foliodim entry, so make one.
-                          //generate canvas values for foliodim
-                          canvasHeight = 1000;
-                          canvasWidth = storedDims.width * canvasHeight / storedDims.height; 
-                          //System.out.println("Need to make folio dims record");
-                          createFolioDimsRecord(storedDims.width, storedDims.height, canvasWidth, canvasHeight, f.getFolioNumber());
-                      }
-                  }
-                  else{ //We were unable to resolve the image or for some reason it is 0, we must continue forward with values of 0
-                      canvasHeight = 0;
-                      canvasWidth = 0;
-                  }
-            }
-            else{ //define a 0, 0 storedDims
-                storedDims = new Dimension(0,0);
-            }
-            result.put("width", canvasWidth);
-            result.put("height", canvasHeight);
-            List<Object> images = new ArrayList<>();
-            Map<String, Object> imageAnnot = new LinkedHashMap<>();
-            imageAnnot.put("@type", "oa:Annotation");
-            imageAnnot.put("motivation", "sc:painting");
-            String imageURL = f.getImageURL();
-            if (imageURL.startsWith("/")) {
-                imageURL = String.format("%spageImage?folio=%s",getRbTok("SERVERURL"), f.getFolioNumber());
-            }
-            Map<String, Object> imageResource = buildQuickMap("@id", imageURL, "@type", "dctypes:Image", "format", "image/jpeg");
-
-            if (storedDims.height > 0) { //We could ignore this and put the 0's into the image annotation
-                //doing this check will return invalid images because we will not include height and width of 0.
-               imageResource.put("height", storedDims.height ); 
-               imageResource.put("width", storedDims.width ); 
-            }
-            imageAnnot.put("resource", imageResource);
-            imageAnnot.put("on", canvasID);
-            images.add(imageAnnot);
-            //If this list was somehow stored in the SQL DB, we could skip calling to the store every time.
-            //System.out.println("Get otherContent");
-            //System.out.println(projID + "  " + canvasID + "  " + f.getFolioNumber() + "  " + u.getUID());;
-            //otherContent = getAnnotationListsForProject(-, canvasID, 0);
-            //otherContent = getLinesForProject(projID, canvasID, f.getFolioNumber(), 0); //Can be an empty array now.
-            //System.out.println("Finalize result");
-            //result.put("otherContent", otherContent);
-            result.put("images", images);
-            //System.out.println("Return");
-            return result;
-        }
-        catch(Exception e){
-            //Map<String, Object> empty = new LinkedHashMap<>();
-            JSONObject empty = new JSONObject();
-            LOG.log(SEVERE, null, "Could not build page for canvas/"+f.getFolioNumber());
-            return empty;
-        }
-   }
-
-   /**
-    * Builds the JSON representation of canvas according to presentation 3 standard and returns it
-    * */
-    private JSONObject buildPage(Folio f, String profile) throws SQLException, IOException {
-         try {
-             String canvasID = getRbTok("SERVERURL")+"canvas/"+f.getFolioNumber();
-             FolioDims pageDim = new FolioDims(f.getFolioNumber(), true);
-             Dimension storedDims = null;
-             JSONArray otherContent;
-             if (pageDim.getImageHeight() <= 0) { //There was no foliodim entry
-                 storedDims = getImageDimension(f.getFolioNumber());
-                 if(null == storedDims || storedDims.height <=0){ //There was no imagecache entry or a bad one we can't use
-                     // System.out.println("Need to resolve image headers for dimensions");
-                     storedDims = f.getImageDimension(); //Resolve the image headers and get the image dimensions
-                 }
-             }
-             LOG.log(INFO, "pageDim={0}", pageDim);
-             JSONObject result  = new JSONObject();
-             result.put("id", canvasID);
-             result.put("type", "Canvas");
-             result.put("label", buildNoneLanguageMap(f.getPageName()));
-             int canvasHeight = pageDim.getCanvasHeight();
-             int canvasWidth = pageDim.getCanvasWidth();
-             if (storedDims != null) {//Then we were able to resolve image headers and we have good values to run this code block
-                 if(storedDims.height > 0){//The image header resolved to 0, so actually we have bad values.
-                     if(pageDim.getImageHeight() <= 0){ //There was no foliodim entry, so make one.
-                         //generate canvas values for foliodim
-                         canvasHeight = 1000;
-                         canvasWidth = storedDims.width * canvasHeight / storedDims.height;
-                         //System.out.println("Need to make folio dims record");
-                         createFolioDimsRecord(storedDims.width, storedDims.height, canvasWidth, canvasHeight, f.getFolioNumber());
-                     }
-                 }
-                 else{ //We were unable to resolve the image or for some reason it is 0, we must continue forward with values of 0
-                     canvasHeight = 0;
-                     canvasWidth = 0;
-                 }
-             }
-             else{ //define a 0, 0 storedDims
-                 storedDims = new Dimension(0,0);
-             }
-             result.put("width", canvasWidth);
-             result.put("height", canvasHeight);
-             result.put("items", new JSONObject());
-             result.put("annotations", new JSONObject());
-
-             return result;
-         }
-         catch (Exception e) {
-             JSONObject empty = new JSONObject();
-             LOG.log(SEVERE, null, "Could not build page for canvas/"+f.getFolioNumber());
-             return empty;
-         }
-
-    }
     private static final Logger LOG = getLogger(CanvasServlet.class.getName());
     
     private String export(JSONObject data) throws JsonProcessingException {

--- a/src/java/edu/slu/tpen/transfer/JsonLDExporter.java
+++ b/src/java/edu/slu/tpen/transfer/JsonLDExporter.java
@@ -16,11 +16,8 @@ package edu.slu.tpen.transfer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import static edu.slu.tpen.entity.Image.Canvas.getLinesForProject;
-import static edu.slu.util.LangUtils.buildQuickMap;
-import static utils.JsonHelper.buildNoneLanguageMap;     
-import static imageLines.ImageCache.getImageDimension;
-import java.awt.Dimension;
+//import static utils.JsonHelper.buildNoneLanguageMap; 
+import utils.*;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import static java.lang.System.out;
@@ -29,18 +26,14 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import static java.util.logging.Level.INFO;
-import static java.util.logging.Level.SEVERE;
 import java.util.logging.Logger;
 import static java.util.logging.Logger.getLogger;
-import net.sf.json.JSONArray;
 import textdisplay.Folio;
 import static textdisplay.Folio.getRbTok;
-import textdisplay.FolioDims;
-import static textdisplay.FolioDims.createFolioDimsRecord;
 import static textdisplay.Metadata.getMetadataAsJSON;
 import textdisplay.Project;
 import user.User;
+
 
 /**
  * Class which manages serialisation to JSON-LD. Builds a Map containing the
@@ -76,14 +69,14 @@ public JsonLDExporter(Project proj, User u, String profile) throws SQLException,
                manifestData.put("type", "Manifest");
                // Not preferred value
                //Remember that this is a Metadata title, not project name...
-               manifestData.put("label",buildNoneLanguageMap(proj.getProjectName()));
+               manifestData.put("label", JsonHelper.buildNoneLanguageMap(proj.getProjectName()));
                manifestData.put("metadata", getMetadataAsJSON(projID, profile));
 		List<Map<String, Object>> canvasList = new ArrayList<>();
 		int index = 0;
 		for (Folio f : folios) {
 		    System.out.println(f.folioNumber);
 		    index++;
-		    canvasList.add(buildPage(proj.getProjectID(), projName, f, u, "v3"));
+		    canvasList.add(JsonHelper.buildPage(proj.getProjectID(), projName, f, u, "v3"));
 		}
 		manifestData.put("annotations", canvasList );
               
@@ -145,7 +138,7 @@ public JsonLDExporter(Project proj, User u, String profile) throws SQLException,
          for (Folio f : folios) {
              index++;
              //System.out.println("Build page "+index);
-            pageList.add(buildPage(proj.getProjectID(), projName, f, u));
+            pageList.add(JsonHelper.buildPage(proj.getProjectID(), projName, f, u));
          }
          //System.out.println("Put all canvas together");
          pages.put("canvases", pageList);
@@ -161,153 +154,8 @@ public JsonLDExporter(Project proj, User u, String profile) throws SQLException,
       return mapper.writer().withDefaultPrettyPrinter().writeValueAsString(manifestData);
    }
    
-   private Map<String, Object> buildPage(int projID, String projName, Folio f, User u, String profile) throws SQLException
-   {
-	try 
-	{
-		Map<String, Object> result = new LinkedHashMap<>();
-		String canvasID = getRbTok("SERVERURL")+"canvas/"+f.getFolioNumber();
-		FolioDims pageDim = new FolioDims(f.getFolioNumber(), true);
-		Dimension storedDims = null;
+   
 
-		JSONArray otherContent;
-		if (pageDim.getImageHeight() <= 0) { //There was no foliodim entry
-		   storedDims = getImageDimension(f.getFolioNumber());
-		   if(null == storedDims || storedDims.height <=0){ //There was no imagecache entry or a bad one we can't use
-		      // System.out.println("Need to resolve image headers for dimensions");
-		      storedDims = f.getImageDimension(); //Resolve the image headers and get the image dimensions
-		   }
-		}
 
-		result.put("id", canvasID);
-		result.put("type", "Canvas");
-		result.put("label", buildNoneLanguageMap(f.getPageName()));
-		int canvasHeight = pageDim.getCanvasHeight();
-		int canvasWidth = pageDim.getCanvasWidth();
-		if (storedDims != null) {//Then we were able to resolve image headers and we have good values to run this code block
-		      if(storedDims.height > 0){//The image header resolved to 0, so actually we have bad values.
-			  if(pageDim.getImageHeight() <= 0){ //There was no foliodim entry, so make one.
-			      //generate canvas values for foliodim
-			      canvasHeight = 1000;
-			      canvasWidth = storedDims.width * canvasHeight / storedDims.height; 
-			      //System.out.println("Need to make folio dims record");
-			      createFolioDimsRecord(storedDims.width, storedDims.height, canvasWidth, canvasHeight, f.getFolioNumber());
-			  }
-		      }
-		      else{ //We were unable to resolve the image or for some reason it is 0, we must continue forward with values of 0
-			  canvasHeight = 0;
-			  canvasWidth = 0;
-		      }
-		}
-		else{ //define a 0, 0 storedDims
-		    storedDims = new Dimension(0,0);
-		}
-		result.put("width", canvasWidth);
-		result.put("height", canvasHeight);
-		
-		//AnnotationPage
-		String pageID = getRbTok("SERVERURL")+"annotations/"+f.getFolioNumber();
-		Map<String, Object> page = new LinkedHashMap<>();
-		page.put("id", pageID);
-		page.put("type", "AnnotationPage");
-		page.put("label", buildNoneLanguageMap(canvasID + " List"));
-		page.put("target", canvasID);
-		page.put("items", new Object[] {});
-		result.put("items", page);
-		return result;
-	}
-	catch (Exception e)
-	{
-		Map<String, Object> empty = new LinkedHashMap<>();
-		LOG.log(SEVERE, null, "Could not build page for canvas/"+f.getFolioNumber());
-		return empty;
-	}
-   }
-
-   /**
-    * Get the map which contains the serialisable information for the given
-    * page.
-    *
-    * @param f the folio to be exported
-    * @return a map containing the relevant info, suitable for Jackson
-    * serialisation
-    */
-    private Map<String, Object> buildPage(int projID, String projName, Folio f, User u) throws SQLException, IOException {
-      
-        try{
-            String canvasID = getRbTok("SERVERURL")+"canvas/"+f.getFolioNumber();
-            FolioDims pageDim = new FolioDims(f.getFolioNumber(), true);
-            Dimension storedDims = null;
-
-            JSONArray otherContent;
-            if (pageDim.getImageHeight() <= 0) { //There was no foliodim entry
-               storedDims = getImageDimension(f.getFolioNumber());
-               if(null == storedDims || storedDims.height <=0){ //There was no imagecache entry or a bad one we can't use
-                  // System.out.println("Need to resolve image headers for dimensions");
-                  storedDims = f.getImageDimension(); //Resolve the image headers and get the image dimensions
-               }
-            }
-
-            LOG.log(INFO, "pageDim={0}", pageDim);
-            Map<String, Object> result = new LinkedHashMap<>();
-            result.put("@id", canvasID);
-            result.put("@type", "sc:Canvas");
-            result.put("label", f.getPageName());
-            int canvasHeight = pageDim.getCanvasHeight();
-            int canvasWidth = pageDim.getCanvasWidth();
-            if (storedDims != null) {//Then we were able to resolve image headers and we have good values to run this code block
-                  if(storedDims.height > 0){//The image header resolved to 0, so actually we have bad values.
-                      if(pageDim.getImageHeight() <= 0){ //There was no foliodim entry, so make one.
-                          //generate canvas values for foliodim
-                          canvasHeight = 1000;
-                          canvasWidth = storedDims.width * canvasHeight / storedDims.height; 
-                          //System.out.println("Need to make folio dims record");
-                          createFolioDimsRecord(storedDims.width, storedDims.height, canvasWidth, canvasHeight, f.getFolioNumber());
-                      }
-                  }
-                  else{ //We were unable to resolve the image or for some reason it is 0, we must continue forward with values of 0
-                      canvasHeight = 0;
-                      canvasWidth = 0;
-                  }
-            }
-            else{ //define a 0, 0 storedDims
-                storedDims = new Dimension(0,0);
-            }
-            result.put("width", canvasWidth);
-            result.put("height", canvasHeight);
-            List<Object> images = new ArrayList<>();
-            Map<String, Object> imageAnnot = new LinkedHashMap<>();
-            imageAnnot.put("@type", "oa:Annotation");
-            imageAnnot.put("motivation", "sc:painting");
-            String imageURL = f.getImageURL();
-            if (imageURL.startsWith("/")) {
-                imageURL = String.format("%spageImage?folio=%s",getRbTok("SERVERURL"), f.getFolioNumber());
-            }
-            Map<String, Object> imageResource = buildQuickMap("@id", imageURL, "@type", "dctypes:Image", "format", "image/jpeg");
-
-            if (storedDims.height > 0) { //We could ignore this and put the 0's into the image annotation
-                //doing this check will return invalid images because we will not include height and width of 0.
-               imageResource.put("height", storedDims.height ); 
-               imageResource.put("width", storedDims.width ); 
-            }
-            imageAnnot.put("resource", imageResource);
-            imageAnnot.put("on", canvasID);
-            images.add(imageAnnot);
-            //If this list was somehow stored in the SQL DB, we could skip calling to the store every time.
-            //System.out.println("Get otherContent");
-            //System.out.println(projID + "  " + canvasID + "  " + f.getFolioNumber() + "  " + u.getUID());
-            otherContent = getLinesForProject(projID, canvasID, f.getFolioNumber(), u.getUID()); //Can be an empty array now.
-            //System.out.println("Finalize result");
-            result.put("otherContent", otherContent);
-            result.put("images", images);
-            //System.out.println("Return");
-            return result;
-        }
-        catch(Exception e){
-            Map<String, Object> empty = new LinkedHashMap<>();
-            LOG.log(SEVERE, null, "Could not build page for canvas/"+f.getFolioNumber());
-            return empty;
-        }
-   }
    private static final Logger LOG = getLogger(JsonLDExporter.class.getName());
 }

--- a/src/java/edu/slu/tpen/transfer/JsonLDExporter.java
+++ b/src/java/edu/slu/tpen/transfer/JsonLDExporter.java
@@ -204,6 +204,16 @@ public JsonLDExporter(Project proj, User u, String profile) throws SQLException,
 		}
 		result.put("width", canvasWidth);
 		result.put("height", canvasHeight);
+		
+		//AnnotationPage
+		String pageID = getRbTok("SERVERURL")+"annotations/"+f.getFolioNumber();
+		Map<String, Object> page = new LinkedHashMap<>();
+		page.put("id", pageID);
+		page.put("type", "AnnotationPage");
+		page.put("label", buildNoneLanguageMap(canvasID + " List"));
+		page.put("target", canvasID);
+		page.put("items", new Object[] {});
+		result.put("items", page);
 		return result;
 	}
 	catch (Exception e)

--- a/src/java/edu/slu/tpen/transfer/JsonLDExporter.java
+++ b/src/java/edu/slu/tpen/transfer/JsonLDExporter.java
@@ -78,6 +78,14 @@ public JsonLDExporter(Project proj, User u, String profile) throws SQLException,
                //Remember that this is a Metadata title, not project name...
                manifestData.put("label",buildNoneLanguageMap(proj.getProjectName()));
                manifestData.put("metadata", getMetadataAsJSON(projID, profile));
+		List<Map<String, Object>> canvasList = new ArrayList<>();
+		int index = 0;
+		for (Folio f : folios) {
+		    System.out.println(f.folioNumber);
+		    index++;
+		    canvasList.add(buildPage(proj.getProjectID(), projName, f, u, "v3"));
+		}
+		manifestData.put("annotations", canvasList );
               
        }
        else{
@@ -151,6 +159,25 @@ public JsonLDExporter(Project proj, User u, String profile) throws SQLException,
         out.println("Send out manifest");
       ObjectMapper mapper = new ObjectMapper();
       return mapper.writer().withDefaultPrettyPrinter().writeValueAsString(manifestData);
+   }
+   
+   private Map<String, Object> buildPage(int projID, String projName, Folio f, User u, String profile) throws SQLException
+   {
+	try 
+	{
+		Map<String, Object> result = new LinkedHashMap<>();
+		String canvasID = getRbTok("SERVERURL")+"canvas/"+f.getFolioNumber();
+		result.put("id", canvasID);
+		result.put("type", "Canvas");
+		result.put("label", buildNoneLanguageMap(f.getPageName()));
+		return result;
+	}
+	catch (Exception e)
+	{
+		Map<String, Object> empty = new LinkedHashMap<>();
+		LOG.log(SEVERE, null, "Could not build page for canvas/"+f.getFolioNumber());
+		return empty;
+	}
    }
 
    /**

--- a/src/java/utils/JsonHelper.java
+++ b/src/java/utils/JsonHelper.java
@@ -33,17 +33,17 @@ import user.User;
  */
 public class JsonHelper {
     private static final Logger LOG = getLogger(JsonHelper.class.getName());
-    public static JSONObject buildNoneLanguageMap(String label)
+    public static HashMap buildNoneLanguageMap(String label)
     {
-        JSONObject languageMap = new JSONObject();
+        HashMap<String, String[]> languageMap = new LinkedHashMap();
         String[] noneMap = new String[] {label};
         languageMap.put("none", noneMap);
         return languageMap;
     }
 
-    public static JSONObject buildLanguageMap(String language, String label)
+    public static HashMap buildLanguageMap(String language, String label)
     {
-	JSONObject languageMap = new JSONObject();
+	HashMap<String, String[]> languageMap = new LinkedHashMap();
         String[] noneMap = new String[] {label};
         languageMap.put(language, noneMap);
         return languageMap;
@@ -55,9 +55,9 @@ public class JsonHelper {
     * */
     private static HashMap formatTextualBody()
     {
-        HashMap<String, JSONObject> map = new HashMap();
+        HashMap<String, HashMap> map = new HashMap();
         
-        JSONObject textMap = new JSONObject();
+        HashMap<String, String> textMap = new LinkedHashMap();
         textMap.put("type", "TextualBody");
         textMap.put("format", "text/plain");
         map.put("cnt:ContentAsText", textMap);
@@ -70,10 +70,9 @@ public class JsonHelper {
      * Make a body property for annotations according to IIIF v3 API using @type and value from v2
      * works based on map build by formatTextualBody() and throws NoSuchElementException if type was not found among keys
      * */
-    public static JSONObject buildAnnotationBody(String type, String value) throws NoSuchElementException
+    public static HashMap buildAnnotationBody(String type, String value) throws NoSuchElementException
     {
-        // since jsonobject extends object, casting should be safe
-        JSONObject body = (JSONObject) formatTextualBody().get(type);
+        HashMap body = (HashMap) formatTextualBody().get(type);
         if (body == null)
         {
             throw new NoSuchElementException(type + " was not found among supported types: " + formatTextualBody().keySet().toString());
@@ -83,9 +82,9 @@ public class JsonHelper {
         return body;
     }
 
-    public static JSONObject buildAnnotationBody(String type, String value, String purpose) throws NoSuchElementException
+    public static HashMap buildAnnotationBody(String type, String value, String purpose) throws NoSuchElementException
     {
-        JSONObject body = buildAnnotationBody(type, value);
+        HashMap body = buildAnnotationBody(type, value);
         body.put("purpose", purpose);
         return body;
     }
@@ -244,7 +243,7 @@ public class JsonHelper {
         build the JSON representation of a canvas and return it.  It will not know about the project, so otherContent will contains all annotation lists this canvas
         has across all projects.  It will ignore all user checks so as to be open.  
     */
-     public static JSONObject buildPage(Folio f) throws SQLException, IOException {
+     public static Map<String, Object> buildPage(Folio f) throws SQLException, IOException {
          
      try{
             String canvasID = getRbTok("SERVERURL")+"canvas/"+f.getFolioNumber();
@@ -259,7 +258,7 @@ public class JsonHelper {
                }
             }
             LOG.log(INFO, "pageDim={0}", pageDim);
-            JSONObject result  = new JSONObject();
+            Map<String, Object> result  = new LinkedHashMap();
             //Map<String, Object> result = new LinkedHashMap<>();
             result.put("@context","http://iiif.io/api/presentation/2/context.json");
             result.put("@id", canvasID);
@@ -318,7 +317,7 @@ public class JsonHelper {
         }
         catch(Exception e){
             //Map<String, Object> empty = new LinkedHashMap<>();
-            JSONObject empty = new JSONObject();
+            Map<String, Object> empty = new LinkedHashMap();
             LOG.log(SEVERE, null, "Could not build page for canvas/"+f.getFolioNumber());
             return empty;
         }
@@ -327,7 +326,7 @@ public class JsonHelper {
    /**
     * Builds the JSON representation of canvas according to presentation 3 standard and returns it
     * */
-    public static JSONObject buildPage(Folio f, String profile) throws SQLException, IOException {
+    public static Map<String, Object> buildPage(Folio f, String profile) throws SQLException, IOException {
          try {
              String canvasID = getRbTok("SERVERURL")+"canvas/"+f.getFolioNumber();
              FolioDims pageDim = new FolioDims(f.getFolioNumber(), true);
@@ -341,7 +340,7 @@ public class JsonHelper {
                  }
              }
              LOG.log(INFO, "pageDim={0}", pageDim);
-             JSONObject result  = new JSONObject();
+             Map<String, Object> result  = new HashMap();
              result.put("id", canvasID);
              result.put("type", "Canvas");
              result.put("label", buildNoneLanguageMap(f.getPageName()));
@@ -367,13 +366,13 @@ public class JsonHelper {
              }
              result.put("width", canvasWidth);
              result.put("height", canvasHeight);
-             result.put("items", new JSONObject());
-             result.put("annotations", new JSONObject());
+             result.put("items", new HashMap());
+             result.put("annotations", new HashMap());
 
              return result;
          }
          catch (Exception e) {
-             JSONObject empty = new JSONObject();
+             HashMap<String, Object> empty = new HashMap();
              LOG.log(SEVERE, null, "Could not build page for canvas/"+f.getFolioNumber());
              return empty;
          }

--- a/src/java/utils/JsonHelper.java
+++ b/src/java/utils/JsonHelper.java
@@ -1,15 +1,38 @@
 package utils;
 
+import static edu.slu.tpen.entity.Image.Canvas.getLinesForProject;
+import edu.slu.tpen.transfer.JsonLDExporter;
+import static edu.slu.util.LangUtils.buildQuickMap;
+import static imageLines.ImageCache.getImageDimension;
+import java.awt.Dimension;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
-
+import static java.util.logging.Level.INFO;
+import static java.util.logging.Level.SEVERE;
+import java.util.logging.Logger;
+import static java.util.logging.Logger.getLogger;
+import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
+import textdisplay.Folio;
+import static textdisplay.Folio.getRbTok;
+import textdisplay.FolioDims;
+import static textdisplay.FolioDims.createFolioDimsRecord;
+import user.User;
+
+
 
 /**
  *
  * @author markskroba
  */
 public class JsonHelper {
+    private static final Logger LOG = getLogger(JsonHelper.class.getName());
     public static JSONObject buildNoneLanguageMap(String label)
     {
         JSONObject languageMap = new JSONObject();
@@ -65,6 +88,296 @@ public class JsonHelper {
         JSONObject body = buildAnnotationBody(type, value);
         body.put("purpose", purpose);
         return body;
+    }
+    
+    
+    
+    /**
+    * Get the map which contains the serialisable information for the given
+    * page.
+    *
+    * @param f the folio to be exported
+    * @return a map containing the relevant info, suitable for Jackson
+    * serialisation
+    */
+    public static Map<String, Object> buildPage(int projID, String projName, Folio f, User u) throws SQLException, IOException {
+        try{
+            String canvasID = getRbTok("SERVERURL")+"canvas/"+f.getFolioNumber();
+            FolioDims pageDim = new FolioDims(f.getFolioNumber(), true);
+            Dimension storedDims = null;
+
+            JSONArray otherContent;
+            if (pageDim.getImageHeight() <= 0) { //There was no foliodim entry
+               storedDims = getImageDimension(f.getFolioNumber());
+               if(null == storedDims || storedDims.height <=0){ //There was no imagecache entry or a bad one we can't use
+                  // System.out.println("Need to resolve image headers for dimensions");
+                  storedDims = f.getImageDimension(); //Resolve the image headers and get the image dimensions
+               }
+            }
+
+            LOG.log(INFO, "pageDim={0}", pageDim);
+            Map<String, Object> result = new LinkedHashMap<>();
+            result.put("@id", canvasID);
+            result.put("@type", "sc:Canvas");
+            result.put("label", f.getPageName());
+            int canvasHeight = pageDim.getCanvasHeight();
+            int canvasWidth = pageDim.getCanvasWidth();
+            if (storedDims != null) {//Then we were able to resolve image headers and we have good values to run this code block
+                  if(storedDims.height > 0){//The image header resolved to 0, so actually we have bad values.
+                      if(pageDim.getImageHeight() <= 0){ //There was no foliodim entry, so make one.
+                          //generate canvas values for foliodim
+                          canvasHeight = 1000;
+                          canvasWidth = storedDims.width * canvasHeight / storedDims.height; 
+                          //System.out.println("Need to make folio dims record");
+                          createFolioDimsRecord(storedDims.width, storedDims.height, canvasWidth, canvasHeight, f.getFolioNumber());
+                      }
+                  }
+                  else{ //We were unable to resolve the image or for some reason it is 0, we must continue forward with values of 0
+                      canvasHeight = 0;
+                      canvasWidth = 0;
+                  }
+            }
+            else{ //define a 0, 0 storedDims
+                storedDims = new Dimension(0,0);
+            }
+            result.put("width", canvasWidth);
+            result.put("height", canvasHeight);
+            List<Object> images = new ArrayList<>();
+            Map<String, Object> imageAnnot = new LinkedHashMap<>();
+            imageAnnot.put("@type", "oa:Annotation");
+            imageAnnot.put("motivation", "sc:painting");
+            String imageURL = f.getImageURL();
+            if (imageURL.startsWith("/")) {
+                imageURL = String.format("%spageImage?folio=%s",getRbTok("SERVERURL"), f.getFolioNumber());
+            }
+            Map<String, Object> imageResource = buildQuickMap("@id", imageURL, "@type", "dctypes:Image", "format", "image/jpeg");
+
+            if (storedDims.height > 0) { //We could ignore this and put the 0's into the image annotation
+                //doing this check will return invalid images because we will not include height and width of 0.
+               imageResource.put("height", storedDims.height ); 
+               imageResource.put("width", storedDims.width ); 
+            }
+            imageAnnot.put("resource", imageResource);
+            imageAnnot.put("on", canvasID);
+            images.add(imageAnnot);
+            //If this list was somehow stored in the SQL DB, we could skip calling to the store every time.
+            //System.out.println("Get otherContent");
+            //System.out.println(projID + "  " + canvasID + "  " + f.getFolioNumber() + "  " + u.getUID());
+            otherContent = getLinesForProject(projID, canvasID, f.getFolioNumber(), u.getUID()); //Can be an empty array now.
+            //System.out.println("Finalize result");
+            result.put("otherContent", otherContent);
+            result.put("images", images);
+            //System.out.println("Return");
+            return result;
+        }
+        catch(Exception e){
+            Map<String, Object> empty = new LinkedHashMap<>();
+            LOG.log(SEVERE, null, "Could not build page for canvas/"+f.getFolioNumber());
+            return empty;
+        }
+   }
+    
+    public static Map<String, Object> buildPage(int projID, String projName, Folio f, User u, String profile) throws SQLException
+   {
+	try 
+	{
+		Map<String, Object> result = new LinkedHashMap<>();
+		String canvasID = getRbTok("SERVERURL")+"canvas/"+f.getFolioNumber();
+		FolioDims pageDim = new FolioDims(f.getFolioNumber(), true);
+		Dimension storedDims = null;
+
+		JSONArray otherContent;
+		if (pageDim.getImageHeight() <= 0) { //There was no foliodim entry
+		   storedDims = getImageDimension(f.getFolioNumber());
+		   if(null == storedDims || storedDims.height <=0){ //There was no imagecache entry or a bad one we can't use
+		      // System.out.println("Need to resolve image headers for dimensions");
+		      storedDims = f.getImageDimension(); //Resolve the image headers and get the image dimensions
+		   }
+		}
+
+		result.put("id", canvasID);
+		result.put("type", "Canvas");
+		result.put("label", buildNoneLanguageMap(f.getPageName()));
+		int canvasHeight = pageDim.getCanvasHeight();
+		int canvasWidth = pageDim.getCanvasWidth();
+		if (storedDims != null) {//Then we were able to resolve image headers and we have good values to run this code block
+		      if(storedDims.height > 0){//The image header resolved to 0, so actually we have bad values.
+			  if(pageDim.getImageHeight() <= 0){ //There was no foliodim entry, so make one.
+			      //generate canvas values for foliodim
+			      canvasHeight = 1000;
+			      canvasWidth = storedDims.width * canvasHeight / storedDims.height; 
+			      //System.out.println("Need to make folio dims record");
+			      createFolioDimsRecord(storedDims.width, storedDims.height, canvasWidth, canvasHeight, f.getFolioNumber());
+			  }
+		      }
+		      else{ //We were unable to resolve the image or for some reason it is 0, we must continue forward with values of 0
+			  canvasHeight = 0;
+			  canvasWidth = 0;
+		      }
+		}
+		else{ //define a 0, 0 storedDims
+		    storedDims = new Dimension(0,0);
+		}
+		result.put("width", canvasWidth);
+		result.put("height", canvasHeight);
+		
+		//AnnotationPage
+		String pageID = getRbTok("SERVERURL")+"annotations/"+f.getFolioNumber();
+		Map<String, Object> page = new LinkedHashMap<>();
+		page.put("id", pageID);
+		page.put("type", "AnnotationPage");
+		page.put("label", buildNoneLanguageMap(canvasID + " List"));
+		page.put("target", canvasID);
+		page.put("items", new Object[] {});
+		result.put("items", page);
+		return result;
+	}
+	catch (Exception e)
+	{
+		Map<String, Object> empty = new LinkedHashMap<>();
+		LOG.log(SEVERE, null, "Could not build page for canvas/"+f.getFolioNumber());
+		return empty;
+	}
+   }
+    
+    /*
+        build the JSON representation of a canvas and return it.  It will not know about the project, so otherContent will contains all annotation lists this canvas
+        has across all projects.  It will ignore all user checks so as to be open.  
+    */
+     public static JSONObject buildPage(Folio f) throws SQLException, IOException {
+         
+     try{
+            String canvasID = getRbTok("SERVERURL")+"canvas/"+f.getFolioNumber();
+            FolioDims pageDim = new FolioDims(f.getFolioNumber(), true);
+            Dimension storedDims = null;
+            JSONArray otherContent;
+            if (pageDim.getImageHeight() <= 0) { //There was no foliodim entry
+               storedDims = getImageDimension(f.getFolioNumber());
+               if(null == storedDims || storedDims.height <=0){ //There was no imagecache entry or a bad one we can't use
+                  // System.out.println("Need to resolve image headers for dimensions");
+                  storedDims = f.getImageDimension(); //Resolve the image headers and get the image dimensions
+               }
+            }
+            LOG.log(INFO, "pageDim={0}", pageDim);
+            JSONObject result  = new JSONObject();
+            //Map<String, Object> result = new LinkedHashMap<>();
+            result.put("@context","http://iiif.io/api/presentation/2/context.json");
+            result.put("@id", canvasID);
+            result.put("@type", "sc:Canvas");
+            result.put("label", f.getPageName());
+            int canvasHeight = pageDim.getCanvasHeight();
+            int canvasWidth = pageDim.getCanvasWidth();
+            if (storedDims != null) {//Then we were able to resolve image headers and we have good values to run this code block
+                  if(storedDims.height > 0){//The image header resolved to 0, so actually we have bad values.
+                      if(pageDim.getImageHeight() <= 0){ //There was no foliodim entry, so make one.
+                          //generate canvas values for foliodim
+                          canvasHeight = 1000;
+                          canvasWidth = storedDims.width * canvasHeight / storedDims.height; 
+                          //System.out.println("Need to make folio dims record");
+                          createFolioDimsRecord(storedDims.width, storedDims.height, canvasWidth, canvasHeight, f.getFolioNumber());
+                      }
+                  }
+                  else{ //We were unable to resolve the image or for some reason it is 0, we must continue forward with values of 0
+                      canvasHeight = 0;
+                      canvasWidth = 0;
+                  }
+            }
+            else{ //define a 0, 0 storedDims
+                storedDims = new Dimension(0,0);
+            }
+            result.put("width", canvasWidth);
+            result.put("height", canvasHeight);
+            List<Object> images = new ArrayList<>();
+            Map<String, Object> imageAnnot = new LinkedHashMap<>();
+            imageAnnot.put("@type", "oa:Annotation");
+            imageAnnot.put("motivation", "sc:painting");
+            String imageURL = f.getImageURL();
+            if (imageURL.startsWith("/")) {
+                imageURL = String.format("%spageImage?folio=%s",getRbTok("SERVERURL"), f.getFolioNumber());
+            }
+            Map<String, Object> imageResource = buildQuickMap("@id", imageURL, "@type", "dctypes:Image", "format", "image/jpeg");
+
+            if (storedDims.height > 0) { //We could ignore this and put the 0's into the image annotation
+                //doing this check will return invalid images because we will not include height and width of 0.
+               imageResource.put("height", storedDims.height ); 
+               imageResource.put("width", storedDims.width ); 
+            }
+            imageAnnot.put("resource", imageResource);
+            imageAnnot.put("on", canvasID);
+            images.add(imageAnnot);
+            //If this list was somehow stored in the SQL DB, we could skip calling to the store every time.
+            //System.out.println("Get otherContent");
+            //System.out.println(projID + "  " + canvasID + "  " + f.getFolioNumber() + "  " + u.getUID());;
+            //otherContent = getAnnotationListsForProject(-, canvasID, 0);
+            //otherContent = getLinesForProject(projID, canvasID, f.getFolioNumber(), 0); //Can be an empty array now.
+            //System.out.println("Finalize result");
+            //result.put("otherContent", otherContent);
+            result.put("images", images);
+            //System.out.println("Return");
+            return result;
+        }
+        catch(Exception e){
+            //Map<String, Object> empty = new LinkedHashMap<>();
+            JSONObject empty = new JSONObject();
+            LOG.log(SEVERE, null, "Could not build page for canvas/"+f.getFolioNumber());
+            return empty;
+        }
+   }
+     
+   /**
+    * Builds the JSON representation of canvas according to presentation 3 standard and returns it
+    * */
+    public static JSONObject buildPage(Folio f, String profile) throws SQLException, IOException {
+         try {
+             String canvasID = getRbTok("SERVERURL")+"canvas/"+f.getFolioNumber();
+             FolioDims pageDim = new FolioDims(f.getFolioNumber(), true);
+             Dimension storedDims = null;
+             JSONArray otherContent;
+             if (pageDim.getImageHeight() <= 0) { //There was no foliodim entry
+                 storedDims = getImageDimension(f.getFolioNumber());
+                 if(null == storedDims || storedDims.height <=0){ //There was no imagecache entry or a bad one we can't use
+                     // System.out.println("Need to resolve image headers for dimensions");
+                     storedDims = f.getImageDimension(); //Resolve the image headers and get the image dimensions
+                 }
+             }
+             LOG.log(INFO, "pageDim={0}", pageDim);
+             JSONObject result  = new JSONObject();
+             result.put("id", canvasID);
+             result.put("type", "Canvas");
+             result.put("label", buildNoneLanguageMap(f.getPageName()));
+             int canvasHeight = pageDim.getCanvasHeight();
+             int canvasWidth = pageDim.getCanvasWidth();
+             if (storedDims != null) {//Then we were able to resolve image headers and we have good values to run this code block
+                 if(storedDims.height > 0){//The image header resolved to 0, so actually we have bad values.
+                     if(pageDim.getImageHeight() <= 0){ //There was no foliodim entry, so make one.
+                         //generate canvas values for foliodim
+                         canvasHeight = 1000;
+                         canvasWidth = storedDims.width * canvasHeight / storedDims.height;
+                         //System.out.println("Need to make folio dims record");
+                         createFolioDimsRecord(storedDims.width, storedDims.height, canvasWidth, canvasHeight, f.getFolioNumber());
+                     }
+                 }
+                 else{ //We were unable to resolve the image or for some reason it is 0, we must continue forward with values of 0
+                     canvasHeight = 0;
+                     canvasWidth = 0;
+                 }
+             }
+             else{ //define a 0, 0 storedDims
+                 storedDims = new Dimension(0,0);
+             }
+             result.put("width", canvasWidth);
+             result.put("height", canvasHeight);
+             result.put("items", new JSONObject());
+             result.put("annotations", new JSONObject());
+
+             return result;
+         }
+         catch (Exception e) {
+             JSONObject empty = new JSONObject();
+             LOG.log(SEVERE, null, "Could not build page for canvas/"+f.getFolioNumber());
+             return empty;
+         }
+
     }
 
 }


### PR DESCRIPTION
This adds `buildPage` method to `jsonldexporter` that is then called in version 3 constructor. JSON that it returns is then added under `annotations`.

The biggest change is that `AnnotationList` is replaced with `AnnotationPage`, as well as how basic properties of Canvas are returned.

The only thing that seems to be missing from is returning actual annotations for each canvas, but it seems it would be a part of #629