### PR TITLE
Adjust Private Image Upload Location

### DIFF
--- a/src/java/ImageUpload/FileUpload.java
+++ b/src/java/ImageUpload/FileUpload.java
@@ -120,7 +120,7 @@ public class FileUpload extends HttpServlet implements Servlet {
                FileItem fileItem = (FileItem)i.next();
                if (fileItem.isFormField() == false) {
                   if (fileItem.getSize() > 0 && fileItem.getSize() < maxSize && fileItem.getName().toLowerCase().endsWith("zip")) {
-                     File f = new File(getRbTok("uploadLocation") + "/" + thisUser.getLname() + thisUser.getUID() + ".zip");
+                     File f = new File(getRbTok("uploadLocation") + "data/userimages" + thisUser.getLname() + thisUser.getUID() + ".zip");
                      fileItem.write(f);
                      Manuscript ms = new Manuscript(repository, archive, collection, city, -999);
                             create(conn, f, thisUser, ms);

--- a/src/java/ImageUpload/FileUpload.java
+++ b/src/java/ImageUpload/FileUpload.java
@@ -120,7 +120,7 @@ public class FileUpload extends HttpServlet implements Servlet {
                FileItem fileItem = (FileItem)i.next();
                if (fileItem.isFormField() == false) {
                   if (fileItem.getSize() > 0 && fileItem.getSize() < maxSize && fileItem.getName().toLowerCase().endsWith("zip")) {
-                     File f = new File(getRbTok("uploadLocation") + "data/userimages" + thisUser.getLname() + thisUser.getUID() + ".zip");
+                     File f = new File(getRbTok("uploadLocation") + "images/userimages/" + thisUser.getLname() + thisUser.getUID() + ".zip");
                      fileItem.write(f);
                      Manuscript ms = new Manuscript(repository, archive, collection, city, -999);
                             create(conn, f, thisUser, ms);

--- a/src/java/ImageUpload/UserImageCollection.java
+++ b/src/java/ImageUpload/UserImageCollection.java
@@ -100,7 +100,7 @@ public class UserImageCollection {
      */
     public static void create(Connection conn, File zippedFile, User uploader, Manuscript ms) throws Exception {
         String directory = getRbTok("uploadLocation");
-        File dir = new File(directory + "data/userimages" + uploader.getLname() + "/" + ms.getID());
+        File dir = new File(directory + "images/userimages/" + uploader.getLname() + "/" + ms.getID());
         if (!dir.exists()) {
             dir.mkdirs();
         }

--- a/src/java/ImageUpload/UserImageCollection.java
+++ b/src/java/ImageUpload/UserImageCollection.java
@@ -100,7 +100,7 @@ public class UserImageCollection {
      */
     public static void create(Connection conn, File zippedFile, User uploader, Manuscript ms) throws Exception {
         String directory = getRbTok("uploadLocation");
-        File dir = new File(directory + "/" + uploader.getLname() + "/" + ms.getID());
+        File dir = new File(directory + "data/userimages" + uploader.getLname() + "/" + ms.getID());
         if (!dir.exists()) {
             dir.mkdirs();
         }

--- a/src/java/edu/slu/tpen/servlet/Constant.java
+++ b/src/java/edu/slu/tpen/servlet/Constant.java
@@ -20,6 +20,6 @@ package edu.slu.tpen.servlet;
  */
 public class Constant {
       public static String ANNOTATION_SERVER_ADDR = "http://store.rerum.io/v1/api";
-      public static String TPEN_CANVAS_PREFIX = "http://tpentest.rerum.io/TPEN";
+      public static String TPEN_CANVAS_PREFIX = "http://newberry.t-pen.org/paleography";
     //public static String ANNOTATION_SERVER_ADDR = "http://localhost:8080/annotationstore";
 }


### PR DESCRIPTION
vlcdhprdp01 has a symlink in `/images/userimages/` to `vlcdhimgp01/data/userimages/`.  Since MySql data private upload image have `/images/userimages/` encoded on them, the properties file notes `uploadLocation=/`.

TPEN cannot write to the root directory `/`.  imageUpload does `File dir = new File(directory + "/" + uploader.getLname() + "/" + ms.getID());` and so is failing.  We are changing image upload java to do `File dir = new File(directory + "images/userimages/" + uploader.getLname() + "/" + ms.getID());`

This was tested and was successful.  It produced http://tpenner.rerum.io/TPEN/transcription.html?projectID=9107